### PR TITLE
fix(windows): dynamically construct Unity executable path

### DIFF
--- a/src/scripts/windows/build.sh
+++ b/src/scripts/windows/build.sh
@@ -40,7 +40,10 @@ build_args=(
 # Versioning of the project needs work. This is how it's done in the GHA:
 # https://github.com/game-ci/unity-builder/blob/main/src/model/versioning.ts
 set -x
-docker exec "$CONTAINER_NAME" powershell "& 'C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe' ${build_args[*]} -logfile | Out-Host"
+docker exec "$CONTAINER_NAME" powershell -Command "
+\$unityExe = 'C:\UnityEditor\' + \$Env:UNITY_VERSION + '\Editor\Unity.exe';
+& \$unityExe ${build_args[*]} -logfile | Out-Host
+"
 exit_code="$?"
 set +x
 

--- a/src/scripts/windows/prepare-env.sh
+++ b/src/scripts/windows/prepare-env.sh
@@ -107,6 +107,7 @@ docker run -dit \
   --env UNITY_USERNAME="$unity_username" \
   --env UNITY_PASSWORD="$unity_password" \
   --env UNITY_SERIAL="$resolved_unity_serial" \
+  --env UNITY_VERSION="$GAMECI_EDITOR_VERSION" \
   --volume "$unity_project_full_path":C:/unity_project \
   --volume "$base_dir"/regkeys:"C:/regkeys" \
   --volume "$base_dir"/build:"C:/build" \
@@ -143,5 +144,9 @@ docker exec "$container_name" powershell "Get-ItemProperty -Path 'HKLM:\SYSTEM\C
 docker exec "$container_name" powershell 'reg import C:\regkeys\winsdk.reg'
 docker exec "$container_name" powershell 'regsvr32 /s C:\ProgramData\Microsoft\VisualStudio\Setup\x64\Microsoft.VisualStudio.Setup.Configuration.Native.dll'
 
-# Activate Unity
-docker exec "$container_name" powershell '& "C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe" -batchmode -quit -nographics -username $Env:UNITY_USERNAME -password $Env:UNITY_PASSWORD -serial $Env:UNITY_SERIAL -logfile | Out-Host'
+echo "Activate Unity"
+
+docker exec "$container_name" powershell -Command "
+\$unityExe = 'C:\UnityEditor\' + \$Env:UNITY_VERSION + '\Editor\Unity.exe';
+& \$unityExe -batchmode -quit -nographics -username \$Env:UNITY_USERNAME -password \$Env:UNITY_PASSWORD -serial \$Env:UNITY_SERIAL -logfile | Out-Host
+"

--- a/src/scripts/windows/return-license.sh
+++ b/src/scripts/windows/return-license.sh
@@ -34,7 +34,10 @@ fi
 
 set -x
 # Return license
-docker exec "$CONTAINER_NAME" powershell '& "C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe" -returnlicense -batchmode -quit -nographics -username $Env:UNITY_USERNAME -password $Env:UNITY_PASSWORD -logfile | Out-Host'
+docker exec "$CONTAINER_NAME" powershell -Command "
+\$unityExe = 'C:\UnityEditor\' + \$Env:UNITY_VERSION + '\Editor\Unity.exe';
+& \$unityExe -returnlicense -batchmode -quit -nographics -username \$Env:UNITY_USERNAME -password \$Env:UNITY_PASSWORD -logfile | Out-Host
+"
 set +x
 
 # Remove the container.

--- a/src/scripts/windows/test.sh
+++ b/src/scripts/windows/test.sh
@@ -33,7 +33,10 @@ test_args=(
 
 # Run the tests.
 set -x
-docker exec "$CONTAINER_NAME" powershell "& 'C:\Program Files\Unity\Hub\Editor\*\Editor\Unity.exe' ${test_args[*]} -logfile | Out-Host"
+docker exec "$CONTAINER_NAME" powershell -Command "
+\$unityExe = 'C:\UnityEditor\' + \$Env:UNITY_VERSION + '\Editor\Unity.exe';
+& \$unityExe ${test_args[*]} -logfile | Out-Host
+"
 set +x
 
 # Install JDK to run Saxon.


### PR DESCRIPTION
### Description
This fix works in `windows-2022` executor, which is the one we use.